### PR TITLE
Añadir autenticación JWT y hash de contraseñas con BCrypt

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "backend",
+      "runtimeExecutable": "backend\\mvnw.cmd",
+      "runtimeArgs": ["-f", "backend\\pom.xml", "spring-boot:run"],
+      "port": 8080
+    },
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--prefix", "frontend"],
+      "port": 5173
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+Sistema de Adopción de Mascotas ("Can Martín") — a pet adoption management platform. Client-server architecture: React (Vite) frontend talking over REST/JSON to a Spring Boot backend, backed by PostgreSQL (Supabase-hosted). Academic project (Herramientas de Desarrollo de Software, UTP).
+
+## Commands
+
+### Frontend (`frontend/`)
+```bash
+cd frontend
+npm install
+npm run dev       # Vite dev server at http://localhost:5173
+npm run build     # production build
+npm run lint      # ESLint
+npm run preview   # preview production build
+```
+There is no frontend test runner configured.
+
+### Backend (`backend/`)
+```bash
+cd backend
+./mvnw spring-boot:run     # run API at http://localhost:8080 (mvnw.cmd on Windows)
+./mvnw test                 # run tests
+./mvnw test -Dtest=ClassName#methodName   # run a single test
+./mvnw clean package        # build jar
+```
+Backend currently has only the default `BackendApplicationTests` context-load test — no real test coverage exists yet.
+
+## Architecture
+
+### Backend layering (`backend/src/main/java/com/example/backend/`)
+Standard Spring Boot layering, one package per concern:
+- `controller/` — `@RestController`s under `/api/**` (e.g. `UsuarioController`, `MascotaController`, `SolicitudAdopcionController`). Controllers catch `RuntimeException` from the service layer and translate to 400/404 responses.
+- `service/` — `@Service` + `@Transactional` business logic; this is where cross-entity rules live (e.g. `SolicitudAdopcionService` flips `Mascota.estado` between `DISPONIBLE`/`EN_PROCESO`/`ADOPTADO` when a solicitud is created/approved/rejected).
+- `repository/` — Spring Data JPA interfaces.
+- `model/` — JPA entities (`Usuario`, `Mascota`, `SolicitudAdopcion`) using Lombok `@Data`. Enums are nested inside the entity that owns them (e.g. `Mascota.Especie`, `Mascota.EstadoMascota`, `Usuario.RolUsuario`, `SolicitudAdopcion.EstadoSolicitud`).
+- `config/` — `CorsConfig` (allowed origins list, shared as a `CorsConfigurationSource` bean) and `SecurityConfig` (wires that bean into the security filter chain).
+- `dto/` — currently minimal (`LoginRequest`); most endpoints accept/return entities directly rather than DTOs.
+
+**Auth model**: There is no JWT/session auth. `SecurityConfig` permits all `/api/**` requests (`permitAll()`), and login (`POST /api/usuarios/login`) does a plaintext password comparison against the stored `contrasena` column. The frontend tracks the logged-in role client-side via `sessionStorage` (`userRole`). Treat this as a known gap, not a pattern to extend — don't assume any endpoint is actually protected server-side.
+
+**Database reality vs. docs**: `application.properties` points at a Postgres/Supabase instance with `spring.jpa.hibernate.ddl-auto=update`, so Hibernate auto-creates/updates the schema from the entities at boot. `docs/database/init.sql` and the root `README.md`, by contrast, describe a manual MySQL setup (`canmartin_db`) — that script is not what actually provisions the live schema. When adding/changing entity fields, the Postgres DB updates itself on next boot; don't expect `init.sql` to be in sync.
+
+### Frontend structure (`frontend/src/`)
+- `pages/` — route-level components, grouped by role/domain: `auth/` (Login, Register), `mascotas/` (public catalog + detail), `adopciones/` (adoptante dashboard, formulario, mis solicitudes, perfil), `admin/` (admin dashboard, gestión de mascotas, solicitudes, usuarios), plus `Home.jsx`.
+- `components/` — presentational components grouped by area (`admin/`, `layout/`, `mascotas/`).
+- `layouts/` — `AdminLayout.jsx` wraps admin pages.
+- `services/` — one file per backend resource (`mascotaService.js`, `userService.js`, `adopcionService.js`), each using raw `fetch` against a hardcoded `const API_URL = "http://localhost:8080/api/..."` at the top of the file. There is no shared Axios instance or central API base-URL config despite `axios` being a dependency — if you add a new service file, follow the existing per-file `fetch` + hardcoded URL pattern for consistency, or raise centralizing it explicitly rather than mixing patterns.
+- Routing lives in `App.jsx` using `react-router-dom`; role-gating (`ADMIN` vs adoptante) is done inline in `<Route>` elements by checking the `userRole` state (sourced from `sessionStorage`), not via a dedicated guard/route component.
+- Styling: Tailwind CSS (`tailwind.config.js`, `postcss.config.js`) plus some plain CSS (`App.css`).
+
+### Entities and relationships
+- `Usuario` (`usuarios`): `rol` enum `ADMIN`/`ADOPTANTE`.
+- `Mascota` (`mascotas`): `especie` (`PERRO`/`GATO`/`OTRO`), `tamanio` (`PEQUENIO`/`MEDIANO`/`GRANDE`), `sexo`, `estado` (`DISPONIBLE`/`EN_PROCESO`/`ADOPTADO`).
+- `SolicitudAdopcion` (`solicitudes_adopcion`): `@ManyToOne` to both `Usuario` and `Mascota` (lazy-fetched, `@JsonIgnoreProperties` on the Hibernate proxy fields to keep JSON serialization clean); `estadoSolicitud` (`PENDIENTE`/`APROBADO`/`RECHAZADO`) drives the `Mascota.estado` transitions mentioned above.
+
+### CORS
+Allowed origins are hardcoded in `backend/.../config/CorsConfig.java` (`localhost:5173`, `:3000`, `:4200` and their `127.0.0.1` equivalents). To add a new frontend origin (e.g. a deployed URL), edit that list directly — see `CORS_CONFIG.md` for more detail.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -56,6 +56,24 @@
         </dependency>
 
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.6</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
@@ -91,6 +109,7 @@
                                 <path>
                                     <groupId>org.projectlombok</groupId>
                                     <artifactId>lombok</artifactId>
+                                    <version>${lombok.version}</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>
@@ -106,6 +125,7 @@
                                 <path>
                                     <groupId>org.projectlombok</groupId>
                                     <artifactId>lombok</artifactId>
+                                    <version>${lombok.version}</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>

--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -1,11 +1,18 @@
 package com.example.backend.config;
 
+import com.example.backend.security.JwtAuthenticationEntryPoint;
+import com.example.backend.security.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
@@ -15,19 +22,57 @@ public class SecurityConfig {
     @Autowired
     private CorsConfigurationSource corsConfigurationSource;  // ← inyectar desde CorsConfig
 
+    @Autowired
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Autowired
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http)
             throws Exception {
         http
                 // Habilitar CORS (inyectado desde CorsConfig)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
-                // Deshabilitar CSRF para desarrollo
+                // Deshabilitar CSRF: API stateless con JWT, no hay sesión/cookies que proteger
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .exceptionHandling(handling -> handling.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 // Autorización de rutas
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/**").permitAll()
+                        // ─── Público ────────────────────────────────
+                        // /error: Spring Boot reenvía aquí las respuestas de error (403, 500, etc.)
+                        // y ese reenvío vuelve a pasar por este filtro de seguridad; si no se permite,
+                        // una denegación 403 legítima se sobreescribe con un 401 del entry point.
+                        .requestMatchers("/error").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/usuarios").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/usuarios/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/mascotas/**").permitAll()
+
+                        // ─── Solo ADMIN ─────────────────────────────
+                        .requestMatchers(HttpMethod.POST, "/api/mascotas/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/mascotas/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/mascotas/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/usuarios").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/usuarios/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/solicitudes-adopcion").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/solicitudes-adopcion/estado/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/solicitudes-adopcion/*/aprobar").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/solicitudes-adopcion/*/rechazar").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/solicitudes-adopcion/**").hasRole("ADMIN")
+
+                        // ─── Resto de /api/**: cualquier usuario autenticado ──
+                        .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/example/backend/controller/UsuarioController.java
+++ b/backend/src/main/java/com/example/backend/controller/UsuarioController.java
@@ -1,6 +1,9 @@
 package com.example.backend.controller;
 
+import com.example.backend.dto.AuthResponse;
+import com.example.backend.dto.LoginRequest;
 import com.example.backend.model.Usuario;
+import com.example.backend.security.JwtUtil;
 import com.example.backend.service.UsuarioService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,9 @@ public class UsuarioController {
 
     @Autowired
     private UsuarioService usuarioService;
+
+    @Autowired
+    private JwtUtil jwtUtil;
 
     // ─── GET: Listar todos los usuarios ────────────────────
     @GetMapping
@@ -84,21 +90,26 @@ public class UsuarioController {
 
     // ─── POST: Iniciar Sesión ──────────────────────────────
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody Usuario loginRequest) {
-        // Buscamos ignorando espacios accidentales en el correo
-        Optional<Usuario> usuarioOpt = usuarioService.buscarPorCorreo(loginRequest.getCorreo().trim());
+    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest) {
+        try {
+            Usuario usuario = usuarioService.autenticar(
+                    loginRequest.getCorreo().trim(),
+                    loginRequest.getContrasena().trim());
 
-        if (usuarioOpt.isPresent()) {
-            Usuario user = usuarioOpt.get();
-            // Comparamos usando .trim() para limpiar espacios invisibles de la base de
-            // datos
-            if (user.getContrasena().trim().equals(loginRequest.getContrasena().trim())) {
-                return ResponseEntity.ok(user);
-            } else {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Contraseña incorrecta");
-            }
+            String token = jwtUtil.generateToken(usuario);
+
+            AuthResponse response = new AuthResponse(
+                    token,
+                    usuario.getId(),
+                    usuario.getNombre(),
+                    usuario.getApellido(),
+                    usuario.getCorreo(),
+                    usuario.getRol().name());
+
+            return ResponseEntity.ok(response);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
         }
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Usuario no encontrado");
     }
 
     // Agrega esto dentro de tu clase UsuarioController

--- a/backend/src/main/java/com/example/backend/dto/AuthResponse.java
+++ b/backend/src/main/java/com/example/backend/dto/AuthResponse.java
@@ -1,0 +1,17 @@
+package com.example.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthResponse {
+    private String token;
+    private Integer id;
+    private String nombre;
+    private String apellido;
+    private String correo;
+    private String rol;
+}

--- a/backend/src/main/java/com/example/backend/dto/LoginRequest.java
+++ b/backend/src/main/java/com/example/backend/dto/LoginRequest.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class LoginRequest {
-    private String email;
-    private String password;
+    private String correo;
+    private String contrasena;
 }

--- a/backend/src/main/java/com/example/backend/model/Usuario.java
+++ b/backend/src/main/java/com/example/backend/model/Usuario.java
@@ -1,5 +1,6 @@
 package com.example.backend.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -27,6 +28,7 @@ public class Usuario {
     @Column(name = "correo", nullable = false, length = 150, unique = true)
     private String correo;
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Column(name = "contrasena", nullable = false, length = 255)
     private String contrasena;
 

--- a/backend/src/main/java/com/example/backend/security/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/example/backend/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package com.example.backend.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                          HttpServletResponse response,
+                          AuthenticationException authException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write("{\"error\": \"No autenticado\"}");
+    }
+}

--- a/backend/src/main/java/com/example/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package com.example.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                     @NonNull HttpServletResponse response,
+                                     @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+
+            if (jwtUtil.validateToken(token)) {
+                String correo = jwtUtil.extractCorreo(token);
+                String rol = jwtUtil.extractRol(token);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                correo,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_" + rol)));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/example/backend/security/JwtUtil.java
+++ b/backend/src/main/java/com/example/backend/security/JwtUtil.java
@@ -1,0 +1,70 @@
+package com.example.backend.security;
+
+import com.example.backend.model.Usuario;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expirationMs;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(Usuario usuario) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expirationMs);
+
+        return Jwts.builder()
+                .subject(usuario.getCorreo())
+                .claim("id", usuario.getId())
+                .claim("rol", usuario.getRol().name())
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public Claims extractClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            extractClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public String extractCorreo(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    public String extractRol(String token) {
+        return extractClaims(token).get("rol", String.class);
+    }
+
+    public Integer extractId(String token) {
+        return extractClaims(token).get("id", Integer.class);
+    }
+}

--- a/backend/src/main/java/com/example/backend/security/PasswordMigrationRunner.java
+++ b/backend/src/main/java/com/example/backend/security/PasswordMigrationRunner.java
@@ -1,0 +1,44 @@
+package com.example.backend.security;
+
+import com.example.backend.model.Usuario;
+import com.example.backend.repository.UsuarioRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PasswordMigrationRunner implements CommandLineRunner {
+
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public PasswordMigrationRunner(UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder) {
+        this.usuarioRepository = usuarioRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void run(String... args) {
+        List<Usuario> usuarios = usuarioRepository.findAll();
+        int migrados = 0;
+
+        for (Usuario usuario : usuarios) {
+            String contrasena = usuario.getContrasena();
+            if (contrasena != null && !isBcryptHash(contrasena)) {
+                usuario.setContrasena(passwordEncoder.encode(contrasena));
+                usuarioRepository.save(usuario);
+                migrados++;
+            }
+        }
+
+        if (migrados > 0) {
+            System.out.println("[PasswordMigrationRunner] Contraseñas migradas a BCrypt: " + migrados);
+        }
+    }
+
+    private boolean isBcryptHash(String value) {
+        return value.startsWith("$2a$") || value.startsWith("$2b$") || value.startsWith("$2y$");
+    }
+}

--- a/backend/src/main/java/com/example/backend/service/UsuarioService.java
+++ b/backend/src/main/java/com/example/backend/service/UsuarioService.java
@@ -3,9 +3,10 @@ package com.example.backend.service;
 import com.example.backend.model.Usuario;
 import com.example.backend.repository.UsuarioRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import java.util.Map;    
-import java.util.HashMap; 
+import java.util.Map;
+import java.util.HashMap;
 
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +18,9 @@ public class UsuarioService {
     @Autowired
     private UsuarioRepository usuarioRepository;
 
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     // ─── Registrar nuevo usuario ───────────────────────────
     public Usuario registrar(Usuario usuario) {
         // Verificar si el correo ya existe
@@ -24,7 +28,20 @@ public class UsuarioService {
             throw new RuntimeException("El correo ya está registrado: "
                     + usuario.getCorreo());
         }
+        usuario.setContrasena(passwordEncoder.encode(usuario.getContrasena()));
         return usuarioRepository.save(usuario);
+    }
+
+    // ─── Autenticar usuario (login) ────────────────────────
+    public Usuario autenticar(String correo, String contrasenaPlano) {
+        Usuario usuario = usuarioRepository.findByCorreo(correo)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+
+        if (!passwordEncoder.matches(contrasenaPlano, usuario.getContrasena())) {
+            throw new RuntimeException("Contraseña incorrecta");
+        }
+
+        return usuario;
     }
 
     // ─── Listar todos los usuarios ─────────────────────────
@@ -60,7 +77,7 @@ public class UsuarioService {
         // LÓGICA INTELIGENTE:
         // Solo actualizamos la contraseña si el frontend envió una nueva
         if (usuarioActualizado.getContrasena() != null && !usuarioActualizado.getContrasena().trim().isEmpty()) {
-            usuarioExistente.setContrasena(usuarioActualizado.getContrasena().trim());
+            usuarioExistente.setContrasena(passwordEncoder.encode(usuarioActualizado.getContrasena().trim()));
         }
 
         return usuarioRepository.save(usuarioExistente);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,3 +13,9 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
+
+# ===============================
+# JWT
+# ===============================
+jwt.secret=zNhHk4397dKONlPWNkozKYoULoTHITPjLzOyM2n64JY1o1JbzZa+64hUmwcFayJz5t5SN9v+ADb4TFZjJ8KCnw==
+jwt.expiration=86400000

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -19,7 +19,8 @@ const Login = ({ onLoginSuccess }) => {
 
     try {
       const user = await loginService(formData);
-      sessionStorage.setItem("userId", user.id); 
+      sessionStorage.setItem("token", user.token);
+      sessionStorage.setItem("userId", user.id);
       const rolDelServidor = user.rol || "ADOPTANTE";
       const formatoRol = rolDelServidor.toUpperCase();
 

--- a/frontend/src/services/adopcionService.js
+++ b/frontend/src/services/adopcionService.js
@@ -1,8 +1,10 @@
+import { authFetch } from "./apiClient";
+
 const API_URL = "http://localhost:8080/api/solicitudes-adopcion";
 
 // 1. Obtener todas las solicitudes (Para el Admin)
 export const obtenerSolicitudes = async () => {
-  const response = await fetch(API_URL);
+  const response = await authFetch(API_URL);
   if (!response.ok) throw new Error('Error al obtener solicitudes');
   return response.json();
 };
@@ -11,37 +13,37 @@ export const obtenerSolicitudes = async () => {
 export const actualizarEstadoSolicitud = async (id, nuevoEstado, observaciones = "Sin observaciones") => {
   // Ajustamos endpoint según tu controlador Java
   const accion = nuevoEstado === 'APROBADO' ? 'aprobar' : 'rechazar';
-  
+
   // Construcción de URL según el método PUT
   let url = `${API_URL}/${id}/${accion}`;
   if (nuevoEstado === 'RECHAZADO') {
     url += `?observaciones=${encodeURIComponent(observaciones)}`;
   }
-  
-  const response = await fetch(url, {
+
+  const response = await authFetch(url, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
   });
-  
+
   if (!response.ok) throw new Error(`Error al ${accion} la solicitud`);
   return response.json();
 };
 
 // 3. Registrar nueva solicitud
 export const registrarSolicitud = async (solicitudData) => {
-  const response = await fetch(API_URL, {
+  const response = await authFetch(API_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(solicitudData),
   });
-  
+
   if (!response.ok) throw new Error('Error al registrar solicitud');
   return response.json();
 }; // <--- AQUÍ SE CIERRA CORRECTAMENTE LA FUNCIÓN registrarSolicitud
 
 // 4. Obtener solicitudes por usuario
 export const obtenerSolicitudesPorUsuario = async (userId) => {
-  const response = await fetch(`${API_URL}/usuario/${userId}`);
+  const response = await authFetch(`${API_URL}/usuario/${userId}`);
   if (!response.ok) throw new Error("Error al obtener solicitudes");
   return await response.json();
 };

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,0 +1,20 @@
+// Wrapper sobre fetch que añade el JWT guardado en sessionStorage a las
+// llamadas que requieren sesión iniciada, y limpia la sesión si el backend
+// responde 401/403 (token ausente, expirado o sin permisos).
+export const authFetch = async (url, options = {}) => {
+  const token = sessionStorage.getItem("token");
+
+  const headers = {
+    ...(options.headers || {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+
+  const response = await fetch(url, { ...options, headers });
+
+  if (response.status === 401 || response.status === 403) {
+    sessionStorage.clear();
+    window.location.href = "/login";
+  }
+
+  return response;
+};

--- a/frontend/src/services/mascotaService.js
+++ b/frontend/src/services/mascotaService.js
@@ -1,3 +1,5 @@
+import { authFetch } from "./apiClient";
+
 const API_URL = "http://localhost:8080/api/mascotas";
 
 // ─── GET: Listar todas las mascotas (Útil para el Dashboard) ────
@@ -11,7 +13,7 @@ export const obtenerTodasLasMascotas = async () => {
     const errorText = await response.text();
     throw new Error(errorText);
   }
-  
+
   return await response.json();
 };
 
@@ -26,13 +28,13 @@ export const obtenerMascotasDisponibles = async () => {
     const errorText = await response.text();
     throw new Error(errorText);
   }
-  
+
   return await response.json();
 };
 
 // ─── POST: Registrar nueva mascota ─────────────────────
 export const registrarMascota = async (mascotaData) => {
-  const response = await fetch(API_URL, {
+  const response = await authFetch(API_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(mascotaData),
@@ -42,13 +44,13 @@ export const registrarMascota = async (mascotaData) => {
     const errorText = await response.text();
     throw new Error(errorText);
   }
-  
+
   return await response.json();
-}; 
+};
 
 // ─── PUT: Actualizar mascota ──────────────────────────
 export const actualizarMascota = async (id, mascotaData) => {
-  const response = await fetch(`${API_URL}/${id}`, {
+  const response = await authFetch(`${API_URL}/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(mascotaData),
@@ -58,13 +60,13 @@ export const actualizarMascota = async (id, mascotaData) => {
     const errorText = await response.text();
     throw new Error(errorText);
   }
-  
+
   return await response.json();
 };
 
 // ─── DELETE: Eliminar mascota ──────────────────────────
 export const eliminarMascota = async (id) => {
-  const response = await fetch(`${API_URL}/${id}`, {
+  const response = await authFetch(`${API_URL}/${id}`, {
     method: "DELETE",
   });
 
@@ -72,6 +74,6 @@ export const eliminarMascota = async (id) => {
     const errorText = await response.text();
     throw new Error(errorText);
   }
-  
+
   return true;
 };

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,3 +1,5 @@
+import { authFetch } from "./apiClient";
+
 const API_URL = "http://localhost:8080/api/usuarios";
 
 // ─── AUTENTICACIÓN Y REGISTRO ──────────────────────────
@@ -8,7 +10,7 @@ export const registerService = async (userData) => {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(userData),
   });
-  
+
   if (!response.ok) {
     const errorText = await response.text();
     throw new Error(errorText);
@@ -22,69 +24,64 @@ export const loginService = async (loginData) => {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(loginData),
   });
-  
+
   if (!response.ok) {
     const errorText = await response.text();
     throw new Error(errorText);
   }
-  return await response.json(); 
+  return await response.json();
 };
 
 // ─── GESTIÓN DE USUARIOS ───────────────────────────────
 
 export const obtenerUsuarios = async () => {
-  const response = await fetch(API_URL, {
+  const response = await authFetch(API_URL, {
     method: "GET",
     headers: { "Content-Type": "application/json" }
   });
-  
+
   if (!response.ok) throw new Error("Error al obtener la lista de usuarios");
   return await response.json();
 };
 
 export const obtenerUsuarioPorId = async (id) => {
-  const response = await fetch(`${API_URL}/${id}`, {
+  const response = await authFetch(`${API_URL}/${id}`, {
     method: "GET",
     headers: { "Content-Type": "application/json" }
   });
-  
+
   if (!response.ok) throw new Error("Error al obtener el usuario");
   return await response.json();
 };
 
 export const actualizarUsuario = async (id, userData) => {
-  const response = await fetch(`${API_URL}/${id}`, {
+  const response = await authFetch(`${API_URL}/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(userData),
   });
-  
+
   if (!response.ok) throw new Error("Error al actualizar el usuario");
   return await response.json();
 };
 
 export const eliminarUsuario = async (id) => {
-  const response = await fetch(`${API_URL}/${id}`, {
+  const response = await authFetch(`${API_URL}/${id}`, {
     method: "DELETE"
   });
-  
+
   if (!response.ok) throw new Error("Error al eliminar el usuario");
   return true;
 };
 
-// ... (tus funciones anteriores)
-
 // ─── DASHBOARD ──────────────────────────────────────────
 
 export const obtenerDashboardData = async (userId) => {
-  const response = await fetch(`${API_URL}/stats/${userId}`, {
+  const response = await authFetch(`${API_URL}/stats/${userId}`, {
     method: "GET",
-    headers: { 
-      "Content-Type": "application/json"
-      // Si usas autenticación por tokens, aquí agregarías: "Authorization": `Bearer ${token}`
-    }
+    headers: { "Content-Type": "application/json" }
   });
-  
+
   if (!response.ok) throw new Error("Error al obtener estadísticas del dashboard");
   return await response.json();
 };


### PR DESCRIPTION
El login comparaba contraseñas en texto plano y ningún endpoint de la API estaba realmente protegido (todo /api/** era permitAll). Se agrega autenticación stateless basada en JWT (filtro + entry point 401 propio, con /error permitido para que Spring Boot no sobreescriba un 403 legítimo con un 401 al reenviar internamente), reglas de autorización por rol (público / ADMIN / autenticado) en SecurityConfig, y BCrypt para el almacenamiento y verificación de contraseñas, con un CommandLineRunner idempotente que migra las contraseñas en texto plano existentes en el arranque.

El frontend guarda el token devuelto por /login y lo añade vía un wrapper de fetch (authFetch) a las llamadas que ahora requieren sesión; un 401/403 limpia la sesión y redirige a /login.

De paso: LoginRequest (dto no usado) se pone en uso con los campos correctos, y Usuario.contrasena ya no se serializa en las respuestas.